### PR TITLE
AO-123: Updating library to a version compatible with Tide libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-gateway-api.version>1.20.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.7.0</gravitee-policy-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
-        <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>8.3</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>


### PR DESCRIPTION
Updating library dependency to match Tide security library dependencies. This is required as workaround to not being able to set attributes in the execution context until next gateway release.