### PR TITLE
Bump dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
@@ -16,6 +14,11 @@
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["major"],
       "semanticCommitType": "chore"
     }
   ]

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
@@ -151,7 +152,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,12 @@
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
+
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-
-        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
         <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.7.0</gravitee-policy-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,11 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.3.0</gravitee-common.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
-        <guava.version>26.0-jre</guava.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
 
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
 
-        <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
-        <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.7.0</gravitee-policy-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
-        <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
+        <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
 
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
@@ -104,7 +105,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.61</version>
+            <version>${bcpkix-jdk15on.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <version>1.7.0</version>
 
     <name>Gravitee.io APIM - Policy - Generate JWT</name>
-    <description>Generate a signed JWT Gravitee with a configurable set of claims.</description>
+    <description>Generate a signed JWT token with a configurable set of claims.</description>
 
     <parent>
         <groupId>io.gravitee</groupId>
@@ -34,13 +34,16 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
+        <gravitee-bom.version>6.0.16</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.2.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.3.0</gravitee-common.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
-        <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
         <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
+
+        <!-- Test dependencies -->
+        <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
+        <gravitee-apim-gateway-tests-sdk.version>4.0.10</gravitee-apim-gateway-tests-sdk.version>
 
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
@@ -100,17 +103,23 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${bcpkix-jdk15on.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <!-- Jackson dependencies -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -119,7 +128,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Test scope -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
         <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.16.2</gravitee-common.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,12 +114,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.7.0</gravitee-policy-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <gravitee-common.version>2.3.0</gravitee-common.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
         <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
+        <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
 
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
@@ -93,10 +94,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-            <scope>provided</scope>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind-api.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
+++ b/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
@@ -38,6 +38,7 @@ import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.generatejwt.alg.Signature;
 import io.gravitee.policy.generatejwt.configuration.GenerateJwtPolicyConfiguration;
 import io.gravitee.policy.generatejwt.configuration.X509CertificateChain;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -56,7 +57,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyIntegrationTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.generatejwt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.gravitee.policy.generatejwt.JwtAttributeToHeaderPolicy.GENERATED_JWT_HEADER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.generatejwt.configuration.GenerateJwtPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest
+class GenerateJwtPolicyIntegrationTest extends AbstractPolicyTest<GenerateJwtPolicy, GenerateJwtPolicyConfiguration> {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        super.configurePolicies(policies);
+        policies.put("jwt-attributes-to-headers", PolicyBuilder.build("jwt-attributes-to-headers", JwtAttributeToHeaderPolicy.class));
+    }
+
+    @Test
+    @DisplayName("Should generate a JWT token with custom claims")
+    @DeployApi("/apis/generate-jwt-custom-claims.json")
+    void shouldGenerateJWTWithCustomClaims(HttpClient httpClient) throws InterruptedException, ParseException {
+        wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        List<LoggedRequest> requests = wiremock.findRequestsMatching(getRequestedFor(urlPathEqualTo("/endpoint")).build()).getRequests();
+        assertThat(requests).hasSize(1);
+        String generatedJwt = requests.get(0).getHeader(GENERATED_JWT_HEADER_NAME);
+        SignedJWT signedJWT = SignedJWT.parse(generatedJwt);
+        JWSHeader jwsHeader = signedJWT.getHeader();
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+
+        assertThat(jwsHeader.getAlgorithm()).isEqualTo(JWSAlgorithm.HS256);
+        assertThat(jwsHeader.getKeyID()).isEqualTo("my-kid");
+        assertThat(claimsSet.getJWTID()).isEqualTo("817c6cfa-6ae6-446e-a631-5ded215b404b");
+        assertThat(claimsSet.getStringClaim("claim1")).isEqualTo("claim1-value");
+        assertThat(claimsSet.getClaim("claim2")).isEqualTo("/test");
+    }
+}

--- a/src/test/java/io/gravitee/policy/generatejwt/JwtAttributeToHeaderPolicy.java
+++ b/src/test/java/io/gravitee/policy/generatejwt/JwtAttributeToHeaderPolicy.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.generatejwt;
+
+import static io.gravitee.policy.generatejwt.GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+
+public class JwtAttributeToHeaderPolicy {
+
+    public static final String GENERATED_JWT_HEADER_NAME = "Generated-JWT";
+
+    @OnRequest
+    public void onRequest(Request request, Response response, ExecutionContext executionContext, PolicyChain policyChain) {
+        request.headers().set(GENERATED_JWT_HEADER_NAME, executionContext.getAttribute(CONTEXT_ATTRIBUTE_JWT_GENERATED).toString());
+
+        policyChain.doNext(request, response);
+    }
+}

--- a/src/test/resources/apis/generate-jwt-custom-claims.json
+++ b/src/test/resources/apis/generate-jwt-custom-claims.json
@@ -1,0 +1,70 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Generate JWT",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-generate-jwt",
+          "configuration": {
+            "signature": "HMAC_HS256",
+            "expiresIn": 30,
+            "expiresInUnit": "SECONDS",
+            "issuer": "urn://gravitee-api-gw",
+            "audiences": [
+              "graviteeam"
+            ],
+            "customClaims": [
+              {
+                "name": "claim1",
+                "value": "claim1-value"
+              },
+              {
+                "name": "claim2",
+                "value": "{#request.path}"
+              }
+            ],
+            "id": "817c6cfa-6ae6-446e-a631-5ded215b404b",
+            "kid": "my-kid",
+            "content": "�\u001B�����\u001A\\:w�J�ӵ\u001F/\t\u0017\u000B�j\u001775d�=�F+"
+          }
+        },
+        {
+          "name": "Generate JWT",
+          "description": "",
+          "enabled": true,
+          "policy": "jwt-attributes-to-headers",
+          "configuration": {
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

NA

**Description**

Bump all dependencies and add an integration test
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.1-bump-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.7.1-bump-deps-SNAPSHOT/gravitee-policy-generate-jwt-1.7.1-bump-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
