### PR TITLE
Update the enum value from "PLAIN" to "PEM" and fix dependencies' versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,63 +1,36 @@
 version: 2.1
 
-parameters:
-  gio_action:
-    type: enum
-    enum: [release, pr_build]
-    default: pr_build
-  dry_run:
-    type: boolean
-    default: true
-    description: "Run in dry run mode?"
-  maven_profile_id:
-    type: string
-    default: "gravitee-dry-run"
-    description: "Maven ID of the Maven profile to use for a dry run ?"
-  secrethub_org:
-    type: string
-    default: "gravitee-lab"
-    description: "SecretHub Org to use to fetch secrets ?"
-  secrethub_repo:
-    type: string
-    default: "cicd"
-    description: "SecretHub Repo to use to fetch secrets ?"
+# this allows you to use CircleCI's dynamic configuration feature
+setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@dev:1.0.4
+  gravitee: gravitee-io/gravitee@4.1.1
 
+
+# our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
+# some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  version: 2.1
-  pull_requests:
+  setup_build:
     when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
+      not: << pipeline.git.tag >>
     jobs:
-      - gravitee/pr-build:
-          context: cicd-orchestrator
-  release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
+      - gravitee/setup_plugin-build-config:
+          filters:
+            tags:
+              ignore:
+                - /.*/
+
+  setup_release:
     when:
-      and:
-        - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
+      matches:
+        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+        value: << pipeline.git.tag >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
-          context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
-  release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
-    when:
-      and:
-        - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - << pipeline.parameters.dry_run >>
-    jobs:
-      # return to simple definition :
-      - gravitee/release:
-          context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+      - gravitee/setup_plugin-release-config:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,14 @@ to backend targets, or used in some other way.
 
 When a signed JWT is generated, it is put in the `jwt.generated` attribute of the request execution context.
 
+== Compatibility with APIM
+
+|===
+| Plugin version | APIM version
+| 1.5.x          | 3.x
+| 1.7.x+         | 4.0 to latest
+|===
+
 == Configuration
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.7.0</gravitee-policy-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
         <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.16.2</gravitee-common.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
         <nimbus-jose-jwt.version>7.2.1</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-generate-jwt</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.5.0</version>
 
     <name>Gravitee.io APIM - Policy - Generate JWT</name>
     <description>Description of the Generate JWT Gravitee Policy</description>
@@ -43,6 +43,9 @@
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
     <dependencies>

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -30,7 +30,7 @@
       "default": "INLINE",
       "enum" : [
         "INLINE",
-        "PLAIN",
+        "PEM",
         "JKS",
         "PKCS12"
       ],


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3377
https://github.com/gravitee-io/issues/issues/9389

**Description**

1. Align dependencies' versions with the one from APIM 3.20.x

2. Update the enum value from "PLAIN" to "PEM" in the schema-form.json
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-APIM-3377-fix-key-resolver-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.5.1-APIM-3377-fix-key-resolver-SNAPSHOT/gravitee-policy-generate-jwt-1.5.1-APIM-3377-fix-key-resolver-SNAPSHOT.zip)
  <!-- Version placeholder end -->
