### PR TITLE
Update the enum value from "PLAIN" to "PEM" in the schema-form

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,8 +35,8 @@ When a signed JWT is generated, it is put in the `jwt.generated` attribute of th
 
 |===
 | Plugin version | APIM version
-
-| Up to 1.x                   | All
+| 1.5.x          | 3.x
+| 1.7.x+         | 4.0 to latest
 |===
 
 == Configuration

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -39,7 +39,7 @@
       "default": "INLINE",
       "enum" : [
         "INLINE",
-        "PLAIN",
+        "PEM",
         "JKS",
         "PKCS12"
       ],


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3377
https://github.com/gravitee-io/issues/issues/9389

**Description**

Update the enum value from "PLAIN" to "PEM" in the schema-form.json
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.2-APIM-3377-master-fix-key-resolver-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.7.2-APIM-3377-master-fix-key-resolver-SNAPSHOT/gravitee-policy-generate-jwt-1.7.2-APIM-3377-master-fix-key-resolver-SNAPSHOT.zip)
  <!-- Version placeholder end -->
