### PR TITLE
Add secretBase64Encoded for HMAC algorithms to make this Policy compatible with V4 + base64 encoded secret

### DIFF
--- a/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
+++ b/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
@@ -17,6 +17,7 @@ package io.gravitee.policy.generatejwt;
 
 import static java.security.KeyStore.*;
 
+import com.google.common.primitives.Bytes;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
@@ -43,6 +44,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
@@ -117,7 +119,11 @@ public class GenerateJwtPolicy {
             ) {
                 jwsHeader = new JWSHeader.Builder(configuration.getSignature().getAlg()).keyID(configuration.getKid()).build();
 
-                signer = new MACSigner(configuration.getContent());
+                if (configuration.getSecretBase64Encoded()) {
+                    signer = new MACSigner(java.util.Base64.getDecoder().decode(configuration.getContent()));
+                } else {
+                    signer = new MACSigner(configuration.getContent().getBytes(StandardCharsets.UTF_8));
+                }
             }
 
             JWTClaimsSet claimsSet = buildClaims(executionContext);

--- a/src/main/java/io/gravitee/policy/generatejwt/configuration/GenerateJwtPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/generatejwt/configuration/GenerateJwtPolicyConfiguration.java
@@ -20,11 +20,15 @@ import io.gravitee.policy.generatejwt.alg.Signature;
 import io.gravitee.policy.generatejwt.model.Claim;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Setter
+@Getter
 public class GenerateJwtPolicyConfiguration implements PolicyConfiguration {
 
     private KeyResolver keyResolver = KeyResolver.INLINE;
@@ -55,125 +59,7 @@ public class GenerateJwtPolicyConfiguration implements PolicyConfiguration {
 
     private String subject;
 
+    private Boolean secretBase64Encoded = false;
+
     private List<Claim> customClaims;
-
-    public KeyResolver getKeyResolver() {
-        return keyResolver;
-    }
-
-    public void setKeyResolver(KeyResolver keyResolver) {
-        this.keyResolver = keyResolver;
-    }
-
-    public Signature getSignature() {
-        return signature;
-    }
-
-    public void setSignature(Signature signature) {
-        this.signature = signature;
-    }
-
-    public String getKid() {
-        return kid;
-    }
-
-    public void setKid(String kid) {
-        this.kid = kid;
-    }
-
-    public X509CertificateChain getX509CertificateChain() {
-        return x509CertificateChain;
-    }
-
-    public void setX509CertificateChain(X509CertificateChain x509CertificateChain) {
-        this.x509CertificateChain = x509CertificateChain;
-    }
-
-    public List<String> getAudiences() {
-        return audiences;
-    }
-
-    public void setAudiences(List<String> audiences) {
-        this.audiences = audiences;
-    }
-
-    public long getExpiresIn() {
-        return expiresIn;
-    }
-
-    public void setExpiresIn(long expiresIn) {
-        this.expiresIn = expiresIn;
-    }
-
-    public TimeUnit getExpiresInUnit() {
-        return expiresInUnit;
-    }
-
-    public void setExpiresInUnit(TimeUnit expiresInUnit) {
-        this.expiresInUnit = expiresInUnit;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getIssuer() {
-        return issuer;
-    }
-
-    public void setIssuer(String issuer) {
-        this.issuer = issuer;
-    }
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public void setContent(String content) {
-        this.content = content;
-    }
-
-    public List<Claim> getCustomClaims() {
-        return customClaims;
-    }
-
-    public void setCustomClaims(List<Claim> customClaims) {
-        this.customClaims = customClaims;
-    }
-
-    public String getAlias() {
-        return alias;
-    }
-
-    public void setAlias(String alias) {
-        this.alias = alias;
-    }
-
-    public String getStorepass() {
-        return storepass;
-    }
-
-    public void setStorepass(String storepass) {
-        this.storepass = storepass;
-    }
-
-    public String getKeypass() {
-        return keypass;
-    }
-
-    public void setKeypass(String keypass) {
-        this.keypass = keypass;
-    }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -64,17 +64,38 @@
     "alias" : {
       "type" : "string",
       "title": "Key alias",
-      "description": "Alias used to access a keystore entry. (only for JKS and PKCS#12)"
+      "description": "Alias used to access a keystore entry. (only for JKS and PKCS#12)",
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "value.keyResolver": ["JKS", "PKCS12"]
+          }
+        }
+      }
     },
     "storepass" : {
       "type" : "string",
       "title": "Store password",
-      "description": "Pass used to access the key store. (only for JKS and PKCS#12)"
+      "description": "Pass used to access the key store. (only for JKS and PKCS#12)",
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "value.keyResolver": ["JKS", "PKCS12"]
+          }
+        }
+      }
     },
     "keypass" : {
       "type" : "string",
       "title": "Key password",
-      "description": "Pass used to access the particular key pair's private key. (only for JKS)"
+      "description": "Pass used to access the particular key pair's private key. (only for JKS)",
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "value.keyResolver": ["JKS"]
+          }
+        }
+      }
     },
     "kid" : {
       "type" : "string",
@@ -163,10 +184,18 @@
           "allowDropFileTypes": true
         }
       },
-      "format": "gio-code-editor",
+      "format": "gio-code-editor"
+    },
+    "secretBase64Encoded": {
+        "type" : "boolean",
+        "title": "Secret base64 encoded",
+        "description": "Whether the secret key is base64 encoded. (only for HMAC algorithms)",
+        "default": false,
       "gioConfig": {
-        "monacoEditorConfig": {
-          "language": "json"
+        "displayIf": {
+          "$eq": {
+            "value.signature": ["HMAC_HS256", "HMAC_HS384", "HMAC_HS512"]
+          }
         }
       }
     },

--- a/src/test/resources/apis/generate-jwt-secret-base64.json
+++ b/src/test/resources/apis/generate-jwt-secret-base64.json
@@ -1,0 +1,72 @@
+{
+  "id": "my-api-jwt-secret-base64",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test-jwt-secret-base64",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Generate JWT",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-generate-jwt",
+          "configuration": {
+            "signature": "HMAC_HS256",
+            "expiresIn": 30,
+            "expiresInUnit": "SECONDS",
+            "issuer": "urn://gravitee-api-gw",
+            "audiences": [
+              "graviteeam"
+            ],
+            "customClaims": [
+              {
+                "name": "claim1",
+                "value": "claim1-value"
+              },
+              {
+                "name": "claim2",
+                "value": "{#request.path}"
+              }
+            ],
+            "id": "817c6cfa-6ae6-446e-a631-5ded215b404b",
+            "kid": "my-kid",
+            "//📝 Content Decoded": "I'm a valid Base64 key with at least 256 bits",
+            "content": "SSdtIGEgdmFsaWQgQmFzZTY0IGtleSB3aXRoIGF0IGxlYXN0IDI1NiBiaXRzCg==",
+            "secretBase64Encoded": true
+          }
+        },
+        {
+          "name": "Generate JWT",
+          "description": "",
+          "enabled": true,
+          "policy": "jwt-attributes-to-headers",
+          "configuration": {
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

Par of https://gravitee.atlassian.net/browse/APIM-6589 

**Description**

Add same feature than in https://jwt.io/ with this option : 
![Screenshot 2024-10-03 at 15 44 41](https://github.com/user-attachments/assets/a8e23381-17b5-4722-95cd-2534b99767b8)

😱 Very useful for V4 APIs because if the token is in base64 on v4 APIs it is automatically decoded.


**Additional context**
[JWT-demo-1.json](https://github.com/user-attachments/files/17245634/JWT-demo-1.json)



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.0-add-secretBase64Encoded-option-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.8.0-add-secretBase64Encoded-option-SNAPSHOT/gravitee-policy-generate-jwt-1.8.0-add-secretBase64Encoded-option-SNAPSHOT.zip)
  <!-- Version placeholder end -->
