### PR TITLE
fix: prevent cross-API x5c certificate chain contamination

### DIFF
--- a/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
+++ b/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
@@ -52,19 +52,22 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class GenerateJwtPolicy {
+
+    private static final Logger log = LoggerFactory.getLogger(GenerateJwtPolicy.class);
 
     /**
      * Request attributes
@@ -80,12 +83,9 @@ public class GenerateJwtPolicy {
      * The key is the reference to the file.
      * The value is the loaded signer.
      */
-    private static final Map<String, RSASSASigner> signers = new HashMap<>();
+    static final Map<String, RSASSASigner> signers = new ConcurrentHashMap<>();
 
-    /**
-     * The encoded certificate chain used for the x5c header
-     */
-    private static List<Base64> certificateChain = new ArrayList<>();
+    static final Map<String, List<Base64>> certChains = new ConcurrentHashMap<>();
 
     /**
      * Create a new Generate JWT Policy instance based on its associated configuration
@@ -109,7 +109,7 @@ public class GenerateJwtPolicy {
 
                 JWSHeader.Builder builder = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(configuration.getKid());
                 if (configuration.getX509CertificateChain() == X509CertificateChain.X5C) {
-                    builder.x509CertChain(certificateChain);
+                    builder.x509CertChain(certChains.get(hash));
                 }
                 jwsHeader = builder.build();
             } else if (
@@ -136,6 +136,7 @@ public class GenerateJwtPolicy {
 
             policyChain.doNext(request, response);
         } catch (Exception ex) {
+            log.error("Unable to generate JWT token", ex);
             policyChain.failWith(PolicyResult.failure("Unable to generate JWT token: " + ex.getMessage()));
         }
     }
@@ -155,7 +156,7 @@ public class GenerateJwtPolicy {
 
                     if (configuration.getStorepass() != null) {
                         keyStore.load(readFile(), configuration.getStorepass().toCharArray());
-                        addCertificateChain(keyStore, configuration);
+                        addCertificateChain(hash, keyStore, configuration);
                     }
 
                     KeyStore.PrivateKeyEntry pkEntry = (KeyStore.PrivateKeyEntry) keyStore.getEntry(
@@ -170,7 +171,7 @@ public class GenerateJwtPolicy {
 
                     if (configuration.getStorepass() != null) {
                         keyStore.load(readFile(), configuration.getStorepass().toCharArray());
-                        addCertificateChain(keyStore, configuration);
+                        addCertificateChain(hash, keyStore, configuration);
                     }
 
                     pkEntry =
@@ -196,8 +197,10 @@ public class GenerateJwtPolicy {
         return signer;
     }
 
-    private void addCertificateChain(KeyStore keyStore, GenerateJwtPolicyConfiguration configuration) throws KeyStoreException {
-        certificateChain =
+    private void addCertificateChain(String hash, KeyStore keyStore, GenerateJwtPolicyConfiguration configuration)
+        throws KeyStoreException {
+        certChains.put(
+            hash,
             Arrays
                 .stream(keyStore.getCertificateChain(configuration.getAlias()))
                 .map(c -> {
@@ -207,7 +210,8 @@ public class GenerateJwtPolicy {
                         throw new IllegalArgumentException("Failed to encode certificate.", ex);
                     }
                 })
-                .collect(Collectors.toList());
+                .collect(Collectors.toList())
+        );
     }
 
     private JWTClaimsSet buildClaims(ExecutionContext executionContext) {

--- a/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyCertificateChainContaminationTest.java
+++ b/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyCertificateChainContaminationTest.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -58,6 +59,12 @@ class GenerateJwtPolicyCertificateChainContaminationTest {
     void init() {
         MockitoAnnotations.openMocks(this);
 
+        GenerateJwtPolicy.signers.clear();
+        GenerateJwtPolicy.certChains.clear();
+    }
+
+    @AfterEach
+    void cleanup() {
         GenerateJwtPolicy.signers.clear();
         GenerateJwtPolicy.certChains.clear();
     }

--- a/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyCertificateChainContaminationTest.java
+++ b/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyCertificateChainContaminationTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.generatejwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.nimbusds.jose.util.Base64;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.generatejwt.configuration.GenerateJwtPolicyConfiguration;
+import io.gravitee.policy.generatejwt.configuration.KeyResolver;
+import io.gravitee.policy.generatejwt.configuration.X509CertificateChain;
+import java.io.File;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GenerateJwtPolicyCertificateChainContaminationTest {
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private PolicyChain policyChain;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+
+        GenerateJwtPolicy.signers.clear();
+        GenerateJwtPolicy.certChains.clear();
+    }
+
+    @Test
+    void x5cHeader_shouldNotBeContaminatedAcrossApis() throws Exception {
+        GenerateJwtPolicy policyA = new GenerateJwtPolicy(newJksConfig());
+        GenerateJwtPolicy policyB = new GenerateJwtPolicy(newPkcs12Config());
+
+        List<Base64> x5cA1 = extractX5c(policyA);
+        List<Base64> x5cB = extractX5c(policyB);
+
+        assertThat(x5cA1).as("pre-condition: JKS and PKCS12 keystores must carry distinct certs").isNotEqualTo(x5cB);
+
+        Base64 expectedLeaf = leafCertFromKeystore("/graviteeio.jks", "graviteeio", "graviteeio.my.storepass");
+        assertThat(x5cA1.get(0)).as("API-A x5c leaf must match the certificate loaded from graviteeio.jks").isEqualTo(expectedLeaf);
+
+        List<Base64> x5cA2 = extractX5c(policyA);
+        assertThat(x5cA2).as("API-A x5c must remain stable after API-B initialises").isEqualTo(x5cA1);
+    }
+
+    private List<Base64> extractX5c(GenerateJwtPolicy policy) throws Exception {
+        ExecutionContext ctx = mock(ExecutionContext.class);
+        TemplateEngine templateEngine = mock(TemplateEngine.class);
+        when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+
+        ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+        policy.onRequest(request, response, ctx, policyChain);
+        verify(ctx).setAttribute(eq(GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED), jwtCaptor.capture());
+
+        return SignedJWT.parse(jwtCaptor.getValue()).getHeader().getX509CertChain();
+    }
+
+    private Base64 leafCertFromKeystore(String resource, String alias, String storepass) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        try (InputStream in = GenerateJwtPolicy.class.getResourceAsStream(resource)) {
+            keyStore.load(in, storepass.toCharArray());
+        }
+        Certificate leaf = keyStore.getCertificateChain(alias)[0];
+        return Base64.encode(leaf.getEncoded());
+    }
+
+    private GenerateJwtPolicyConfiguration newJksConfig() throws Exception {
+        GenerateJwtPolicyConfiguration config = mock(GenerateJwtPolicyConfiguration.class);
+        when(config.getKeyResolver()).thenReturn(KeyResolver.JKS);
+        when(config.getAlias()).thenReturn("graviteeio");
+        when(config.getStorepass()).thenReturn("graviteeio.my.storepass");
+        when(config.getKeypass()).thenReturn("graviteeio.my.keypass");
+        when(config.getContent()).thenReturn(getFile("/graviteeio.jks"));
+        when(config.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
+        return config;
+    }
+
+    private GenerateJwtPolicyConfiguration newPkcs12Config() throws Exception {
+        GenerateJwtPolicyConfiguration config = mock(GenerateJwtPolicyConfiguration.class);
+        when(config.getKeyResolver()).thenReturn(KeyResolver.PKCS12);
+        when(config.getAlias()).thenReturn("graviteeio");
+        when(config.getStorepass()).thenReturn("graviteeio.my.storepass");
+        when(config.getContent()).thenReturn(getFile("/graviteeio.p12"));
+        when(config.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
+        return config;
+    }
+
+    private String getFile(String resource) throws Exception {
+        return new File(GenerateJwtPolicy.class.getResource(resource).toURI()).getCanonicalPath();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14576

## Purpose

`GenerateJwtPolicy` cached the JKS/PKCS12 certificate chain used for the `x5c` header in a single class-level static field, shared across every API in the JVM that has this policy configured. Because the signer cache prevents `addCertificateChain` from ever re-running for an already-initialized API, that static field kept whatever certificate the *most recently initialized* API loaded — so an earlier-initialized API would silently emit another API's certificate chain in its `x5c` header. The contamination produces no error; JWTs are generated successfully but with the wrong certificate material.

## Summary of changes

- `GenerateJwtPolicy`: replaced the shared static `certificateChain` field with a `certChains` map keyed by `sha1(content)`, the same key already used by the signer cache, so each API's certificate chain is isolated from every other API's. Both caches are now `ConcurrentHashMap` instead of `HashMap`.
- `addCertificateChain` now takes the content hash and stores into `certChains` under that key instead of reassigning the shared field.
- Added a class-level SLF4J logger and log the caught exception (with stack trace) before failing the policy chain, so cert-encoding/keystore failures are diagnosable from gateway logs instead of only surfacing a generic message to the caller.
- Added `GenerateJwtPolicyCertificateChainContaminationTest`, a regression test that initializes two API configurations with distinct JKS certificates and asserts each continues to emit its own `x5c` chain, anchored against the actual keystore content.

## Known Issues

- Requesting `x509CertificateChain=X5C` with an `INLINE` or `PEM` key resolver silently produces a JWT with no `x5c` header — `addCertificateChain` is only ever invoked from the JKS/PKCS12 branches, so `certChains.get(hash)` is `null` for those resolvers. This is a pre-existing gap unrelated to the contamination this PR fixes; tracked as a known limitation, not addressed here.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.2-andres-osorio-APIM-14576-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.8.2-andres-osorio-APIM-14576-SNAPSHOT/gravitee-policy-generate-jwt-1.8.2-andres-osorio-APIM-14576-SNAPSHOT.zip)
  <!-- Version placeholder end -->
