### PR TITLE
fix: run legacy JUnit4 tests via junit-vintage-engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyTest.java
@@ -44,7 +44,6 @@ import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -545,8 +544,7 @@ public class GenerateJwtPolicyTest {
         byte[] bytes = x509CertChain.get(0).decode();
         try (InputStream stream = new ByteArrayInputStream(bytes)) {
             CertificateFactory factory = CertificateFactory.getInstance("X.509");
-            X509Certificate certificate = (X509Certificate) factory.generateCertificate(stream);
-            certificate.checkValidity();
+            factory.generateCertificate(stream);
         } catch (Exception e) {
             return false;
         }


### PR DESCRIPTION
## Purpose

`GenerateJwtPolicyTest` (~20 tests) is written against `org.junit.Test`/`org.junit.Before` (JUnit4). Because `junit-jupiter-engine` is present on the test classpath transitively, Surefire resolves the JUnit5 platform provider. That provider only discovers tests through registered engines, and without `junit-vintage-engine` there is no engine that understands JUnit4 — so it silently reported "No tests were executed!" when run directly, and silently skipped the whole class during a full `mvn test` run. This predates the class itself; it's a gap in `pom.xml`.

## Summary of changes

- Added `org.junit.vintage:junit-vintage-engine` (test scope) to `pom.xml`, right after the existing `junit:junit` dependency. Version is inherited from the `gravitee-bom`, which already manages it at `5.11.1` — matching the resolved `junit-jupiter-engine` version, so no explicit version was needed.
- Running the legacy suite for the first time surfaced a second, unrelated defect: `shouldSuccess_jksResolver` failed because its assertion helper (`hasValidX509CertificateChain`) called `certificate.checkValidity()` against the checked-in `graviteeio.jks` test keystore, whose certificate expired 2024-07-03. That check verified the fixture's own expiry, not `GenerateJwtPolicy`'s behavior, so it was dropped — the remaining checks (JWS algorithm, `kid`, and certificate chain parseability) still fully cover the policy's x5c-embedding behavior, without being coupled to a wall-clock time bomb that would recur whenever any future fixture certificate expires.

## Testing

`mvn test` now runs all 24 tests (20 previously-silent JUnit4 tests + 4 others) and passes; `mvn prettier:check` is clean.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.1-andres-osorio-junit4-test-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.8.1-andres-osorio-junit4-test-fix-SNAPSHOT/gravitee-policy-generate-jwt-1.8.1-andres-osorio-junit4-test-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
