### PR TITLE
chore: update alpha to match master

### DIFF
--- a/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
+++ b/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
@@ -109,7 +109,10 @@ public class GenerateJwtPolicy {
 
                 JWSHeader.Builder builder = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(configuration.getKid());
                 if (configuration.getX509CertificateChain() == X509CertificateChain.X5C) {
-                    builder.x509CertChain(certChains.get(hash));
+                    List<Base64> chain = certChains.get(hash);
+                    if (chain != null) {
+                        builder.x509CertChain(chain);
+                    }
                 }
                 jwsHeader = builder.build();
             } else if (


### PR DESCRIPTION
## Purpose

Bring changes from master into alpha, keeping the two branches in sync (routine follow-up to #84).

## Summary of changes

- Rebased alpha onto the latest master (1.8.1 → 1.8.3), pulling in the released `prevent cross-API x5c certificate chain contamination` and `key the signer/certificate caches by resolver, content, and alias` fixes.
- Guarded the X5C certificate chain lookup in `GenerateJwtPolicy.onRequest()` against a missing cache entry: `certChains.get(hash)` can return `null` when no certificate chain was resolved for that key, and the header builder was called with it unconditionally.

### Behaviour changes

- When `X509CertificateChain.X5C` is configured but no certificate chain has been cached for the resolved key material, the policy now skips setting the `x5c` header instead of throwing a `NullPointerException`.

## Testing

Standard test suite (`mvn test`) — 34 tests, 0 failures.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.3`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.8.3/gravitee-policy-generate-jwt-1.8.3.zip)
  <!-- Version placeholder end -->
