### PR TITLE
Restore master's JKS/PKCS12 x5c chain-loading behavior

### DIFF
--- a/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
+++ b/src/main/java/io/gravitee/policy/generatejwt/GenerateJwtPolicy.java
@@ -41,6 +41,7 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.generatejwt.alg.Signature;
 import io.gravitee.policy.generatejwt.configuration.GenerateJwtPolicyConfiguration;
+import io.gravitee.policy.generatejwt.configuration.KeyResolver;
 import io.gravitee.policy.generatejwt.configuration.X509CertificateChain;
 import jakarta.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
@@ -203,11 +204,17 @@ public class GenerateJwtPolicy {
     private JWSHeader buildRsaHeader(String hash, PolicyChain policyChain) {
         JWSHeader.Builder builder = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(configuration.getKid());
         if (configuration.getX509CertificateChain() == X509CertificateChain.X5C) {
-            List<Base64> certChain = resolveCertChain(hash, policyChain);
-            if (certChain == null) {
+            List<Base64> certChain = resolveCertChain(hash);
+            if (certChain != null) {
+                builder.x509CertChain(certChain);
+            } else if (!isKeystoreResolver()) {
+                log.error(
+                    "[generate-jwt] x5c certificate chain requested but no certificate chain is available for resolver {} — request rejected.",
+                    configuration.getKeyResolver().name()
+                );
+                policyChain.failWith(PolicyResult.failure(JWT_GENERATION_FAILURE_MESSAGE));
                 return null;
             }
-            builder.x509CertChain(certChain);
         }
         if (configuration.isX509CertSha1Thumbprint()) {
             Base64URL leafCertificate = resolveLeafCertificate(hash, policyChain);
@@ -226,15 +233,14 @@ public class GenerateJwtPolicy {
         return builder.build();
     }
 
-    private List<Base64> resolveCertChain(String hash, PolicyChain policyChain) {
-        return resolveRequiredHeaderValue(
-            certChains,
-            hash,
-            chain -> !chain.isEmpty(),
-            chain -> chain,
-            "[generate-jwt] x5c certificate chain requested but no certificate chain is available for resolver {} — request rejected.",
-            policyChain
-        );
+    private List<Base64> resolveCertChain(String hash) {
+        List<Base64> certChain = certChains.get(hash);
+        return (certChain == null || certChain.isEmpty()) ? null : certChain;
+    }
+
+    private boolean isKeystoreResolver() {
+        KeyResolver keyResolver = configuration.getKeyResolver();
+        return keyResolver == KeyResolver.JKS || keyResolver == KeyResolver.PKCS12;
     }
 
     private Base64URL resolveLeafCertificate(String hash, PolicyChain policyChain) {
@@ -350,7 +356,7 @@ public class GenerateJwtPolicy {
         return (RSAKey) JWK.parseFromPEMEncodedObjects(CERTIFICATE_PEM_BLOCK.matcher(pemContent).replaceAll(""));
     }
 
-    private void logSuppressedChainToggles(String reason) {
+    private void logSuppressedThumbprintToggles(String reason) {
         if (configuration.isX509CertSha1Thumbprint()) {
             log.error(
                 "[generate-jwt] x5t toggle enabled but {} for resolver {} — thumbprint cannot be computed.",
@@ -365,9 +371,13 @@ public class GenerateJwtPolicy {
                 configuration.getKeyResolver().name()
             );
         }
+    }
+
+    private void logSuppressedChainToggles(String reason) {
+        logSuppressedThumbprintToggles(reason);
         if (configuration.getX509CertificateChain() == X509CertificateChain.X5C) {
-            log.error(
-                "[generate-jwt] x5c certificate chain requested but {} for resolver {} — the request will be rejected.",
+            log.warn(
+                "[generate-jwt] x5c certificate chain requested but {} for resolver {} — the x5c header will be omitted.",
                 reason,
                 configuration.getKeyResolver().name()
             );
@@ -379,16 +389,6 @@ public class GenerateJwtPolicy {
         Certificate[] certificateChain = keyStore.getCertificateChain(configuration.getAlias());
         if (certificateChain == null || certificateChain.length == 0) {
             logSuppressedChainToggles("no certificate chain is available");
-            clearCertificateCaches(hash);
-            return;
-        }
-
-        if (leafMatchesSigningKey(certificateChain[0], signingKey, configuration.getKeyResolver().name()) == LeafMatchResult.MISMATCH) {
-            log.warn(
-                "[generate-jwt] keystore certificate chain leaf does not match the signing key for resolver {} — certificate chain will not be embedded.",
-                configuration.getKeyResolver().name()
-            );
-            logSuppressedChainToggles("the keystore certificate chain leaf does not match the signing key");
             clearCertificateCaches(hash);
             return;
         }
@@ -410,6 +410,21 @@ public class GenerateJwtPolicy {
         }
 
         certChains.put(hash, certChain);
+
+        if (leafMatchesSigningKey(certificateChain[0], signingKey, configuration.getKeyResolver().name()) == LeafMatchResult.MISMATCH) {
+            String chainEmbeddingOutcome = configuration.getX509CertificateChain() == X509CertificateChain.X5C
+                ? "the chain is embedded as x5c but no thumbprint is derived from it"
+                : "no thumbprint is derived from it";
+            log.warn(
+                "[generate-jwt] keystore certificate chain leaf does not match the signing key for resolver {} — {}.",
+                configuration.getKeyResolver().name(),
+                chainEmbeddingOutcome
+            );
+            logSuppressedThumbprintToggles("the keystore certificate chain leaf does not match the signing key");
+            leafCertificates.put(hash, Optional.empty());
+            leafCertificatesSha256.put(hash, Optional.empty());
+            return;
+        }
 
         var decodedCert = certChain.get(0).decode();
         leafCertificates.put(hash, Optional.of(computeX5t(decodedCert)));

--- a/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyX5tFailFastTest.java
+++ b/src/test/java/io/gravitee/policy/generatejwt/GenerateJwtPolicyX5tFailFastTest.java
@@ -328,15 +328,18 @@ class GenerateJwtPolicyX5tFailFastTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = KeyResolver.class, names = { "JKS", "PKCS12" })
-    void rejectsRequestWith500_whenX5cEnabledWithThumbprintToggleDisabledAndKeystoreCertificateChainIsNull(KeyResolver keyResolver)
-        throws Exception {
+    @CsvSource({ "JKS, NULL_CHAIN", "JKS, EMPTY_CHAIN", "PKCS12, NULL_CHAIN", "PKCS12, EMPTY_CHAIN" })
+    void signsWithoutX5cHeader_whenX5cEnabledWithThumbprintTogglesDisabledAndKeystoreCertificateChainIsNullOrEmpty(
+        KeyResolver keyResolver,
+        String chainState
+    ) throws Exception {
         String keystoreFile = keyResolver == KeyResolver.JKS ? "/graviteeio.jks" : "/graviteeio.p12";
         String keystorePath = Path.of(getClass().getResource(keystoreFile).toURI()).toString();
         KeyStore.PrivateKeyEntry realPrivateKeyEntry = loadRealPrivateKeyEntry(keyResolver, keystorePath);
 
         when(configuration.getSignature()).thenReturn(Signature.RSA_RS256);
         when(configuration.isX509CertSha1Thumbprint()).thenReturn(false);
+        when(configuration.isX509CertSha256Thumbprint()).thenReturn(false);
         when(configuration.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
         when(configuration.getKeyResolver()).thenReturn(keyResolver);
         when(configuration.getContent()).thenReturn(keystorePath);
@@ -345,7 +348,8 @@ class GenerateJwtPolicyX5tFailFastTest {
         when(configuration.getKeypass()).thenReturn(KEYSTORE_KEYPASS);
 
         KeyStore chainlessKeyStore = mock(KeyStore.class);
-        when(chainlessKeyStore.getCertificateChain(KEYSTORE_ALIAS)).thenReturn(null);
+        Certificate[] certificateChain = "NULL_CHAIN".equals(chainState) ? null : new Certificate[0];
+        when(chainlessKeyStore.getCertificateChain(KEYSTORE_ALIAS)).thenReturn(certificateChain);
         when(chainlessKeyStore.getEntry(eq(KEYSTORE_ALIAS), any())).thenReturn(realPrivateKeyEntry);
 
         try (MockedStatic<KeyStore> keyStoreStatic = mockStatic(KeyStore.class)) {
@@ -355,7 +359,62 @@ class GenerateJwtPolicyX5tFailFastTest {
 
             policy.onRequest(request, response, executionContext, policyChain);
 
-            assertRejectedWith500(1);
+            verify(policyChain, never()).failWith(any());
+            verify(policyChain).doNext(request, response);
+            ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+            verify(executionContext).setAttribute(eq(GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED), jwtCaptor.capture());
+            SignedJWT signedJWT = SignedJWT.parse(jwtCaptor.getValue());
+            assertNull(
+                signedJWT.getHeader().getX509CertChain(),
+                "no x5c header may be emitted when the keystore returns no certificate chain"
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "JKS, NULL_CHAIN", "JKS, EMPTY_CHAIN", "PKCS12, NULL_CHAIN", "PKCS12, EMPTY_CHAIN" })
+    void reOmitsX5cOnWarmRequestWithoutReReadingKeystore_whenX5cEnabledWithThumbprintTogglesDisabledAndKeystoreCertificateChainIsNullOrEmpty(
+        KeyResolver keyResolver,
+        String chainState
+    ) throws Exception {
+        String keystoreFile = keyResolver == KeyResolver.JKS ? "/graviteeio.jks" : "/graviteeio.p12";
+        String keystorePath = Path.of(getClass().getResource(keystoreFile).toURI()).toString();
+        KeyStore.PrivateKeyEntry realPrivateKeyEntry = loadRealPrivateKeyEntry(keyResolver, keystorePath);
+
+        when(configuration.getSignature()).thenReturn(Signature.RSA_RS256);
+        when(configuration.isX509CertSha1Thumbprint()).thenReturn(false);
+        when(configuration.isX509CertSha256Thumbprint()).thenReturn(false);
+        when(configuration.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
+        when(configuration.getKeyResolver()).thenReturn(keyResolver);
+        when(configuration.getContent()).thenReturn(keystorePath);
+        when(configuration.getAlias()).thenReturn(KEYSTORE_ALIAS);
+        when(configuration.getStorepass()).thenReturn(KEYSTORE_STOREPASS);
+        when(configuration.getKeypass()).thenReturn(KEYSTORE_KEYPASS);
+
+        KeyStore chainlessKeyStore = mock(KeyStore.class);
+        Certificate[] certificateChain = "NULL_CHAIN".equals(chainState) ? null : new Certificate[0];
+        when(chainlessKeyStore.getCertificateChain(KEYSTORE_ALIAS)).thenReturn(certificateChain);
+        when(chainlessKeyStore.getEntry(eq(KEYSTORE_ALIAS), any())).thenReturn(realPrivateKeyEntry);
+
+        try (MockedStatic<KeyStore> keyStoreStatic = mockStatic(KeyStore.class)) {
+            keyStoreStatic.when(() -> KeyStore.getInstance(keyResolver.name())).thenReturn(chainlessKeyStore);
+
+            GenerateJwtPolicy policy = new GenerateJwtPolicy(configuration);
+
+            policy.onRequest(request, response, executionContext, policyChain);
+            policy.onRequest(request, response, executionContext, policyChain);
+
+            verify(policyChain, never()).failWith(any());
+            verify(policyChain, times(2)).doNext(request, response);
+            verify(chainlessKeyStore, times(1)).getCertificateChain(KEYSTORE_ALIAS);
+            ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+            verify(executionContext, times(2)).setAttribute(eq(GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED), jwtCaptor.capture());
+            for (String jwt : jwtCaptor.getAllValues()) {
+                assertNull(
+                    SignedJWT.parse(jwt).getHeader().getX509CertChain(),
+                    "no x5c header may be emitted on either the cold or the warm request when the keystore returns no certificate chain"
+                );
+            }
         }
     }
 
@@ -492,6 +551,167 @@ class GenerateJwtPolicyX5tFailFastTest {
             policy.onRequest(request, response, executionContext, policyChain);
 
             assertRejectedWith500(2);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = KeyResolver.class, names = { "JKS", "PKCS12" })
+    void embedsKeystoreCertificateChainAsX5c_whenLeafDoesNotMatchSigningKeyAndThumbprintTogglesDisabled(KeyResolver keyResolver)
+        throws Exception {
+        String keystoreFile = keyResolver == KeyResolver.JKS ? "/graviteeio.jks" : "/graviteeio.p12";
+        String keystorePath = Path.of(getClass().getResource(keystoreFile).toURI()).toString();
+        KeyStore.PrivateKeyEntry realPrivateKeyEntry = loadRealPrivateKeyEntry(keyResolver, keystorePath);
+        Certificate foreignCertificate = foreignLeafCertificate();
+        Certificate[] mismatchedChain = { foreignCertificate, realPrivateKeyEntry.getCertificate() };
+
+        assertFalse(
+            Arrays.equals(realPrivateKeyEntry.getCertificate().getPublicKey().getEncoded(), foreignCertificate.getPublicKey().getEncoded()),
+            "pre-condition: the keystore chain's leaf certificate must carry a different public key than the resolved signing key"
+        );
+
+        when(configuration.getSignature()).thenReturn(Signature.RSA_RS256);
+        when(configuration.isX509CertSha1Thumbprint()).thenReturn(false);
+        when(configuration.isX509CertSha256Thumbprint()).thenReturn(false);
+        when(configuration.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
+        when(configuration.getKeyResolver()).thenReturn(keyResolver);
+        when(configuration.getContent()).thenReturn(keystorePath);
+        when(configuration.getAlias()).thenReturn(KEYSTORE_ALIAS);
+        when(configuration.getStorepass()).thenReturn(KEYSTORE_STOREPASS);
+        when(configuration.getKeypass()).thenReturn(KEYSTORE_KEYPASS);
+
+        KeyStore mismatchedKeyStore = mock(KeyStore.class);
+        when(mismatchedKeyStore.getCertificateChain(KEYSTORE_ALIAS)).thenReturn(mismatchedChain);
+        when(mismatchedKeyStore.getEntry(eq(KEYSTORE_ALIAS), any())).thenReturn(realPrivateKeyEntry);
+
+        try (MockedStatic<KeyStore> keyStoreStatic = mockStatic(KeyStore.class)) {
+            keyStoreStatic.when(() -> KeyStore.getInstance(keyResolver.name())).thenReturn(mismatchedKeyStore);
+
+            GenerateJwtPolicy policy = new GenerateJwtPolicy(configuration);
+
+            policy.onRequest(request, response, executionContext, policyChain);
+
+            verify(policyChain, never()).failWith(any());
+            verify(policyChain).doNext(request, response);
+            ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+            verify(executionContext).setAttribute(eq(GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED), jwtCaptor.capture());
+            SignedJWT signedJWT = SignedJWT.parse(jwtCaptor.getValue());
+            var x5c = signedJWT.getHeader().getX509CertChain();
+            assertNotNull(x5c, "x5c must be populated from the keystore chain even though the leaf does not match the signing key");
+            assertEquals(mismatchedChain.length, x5c.size(), "x5c must contain every certificate returned by the keystore chain");
+            for (int i = 0; i < mismatchedChain.length; i++) {
+                assertArrayEquals(
+                    mismatchedChain[i].getEncoded(),
+                    x5c.get(i).decode(),
+                    "x5c entry " + i + " must be the keystore chain certificate, byte-for-byte, in keystore order"
+                );
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = KeyResolver.class, names = { "JKS", "PKCS12" })
+    void emitsHeaderWithOnlyAlgAndX5cMembers_whenLeafDoesNotMatchSigningKeyAndThumbprintTogglesDisabled(KeyResolver keyResolver)
+        throws Exception {
+        String keystoreFile = keyResolver == KeyResolver.JKS ? "/graviteeio.jks" : "/graviteeio.p12";
+        String keystorePath = Path.of(getClass().getResource(keystoreFile).toURI()).toString();
+        KeyStore.PrivateKeyEntry realPrivateKeyEntry = loadRealPrivateKeyEntry(keyResolver, keystorePath);
+        Certificate foreignCertificate = foreignLeafCertificate();
+        Certificate[] mismatchedChain = { foreignCertificate, realPrivateKeyEntry.getCertificate() };
+
+        assertFalse(
+            Arrays.equals(realPrivateKeyEntry.getCertificate().getPublicKey().getEncoded(), foreignCertificate.getPublicKey().getEncoded()),
+            "pre-condition: the keystore chain's leaf certificate must carry a different public key than the resolved signing key"
+        );
+
+        when(configuration.getSignature()).thenReturn(Signature.RSA_RS256);
+        when(configuration.isX509CertSha1Thumbprint()).thenReturn(false);
+        when(configuration.isX509CertSha256Thumbprint()).thenReturn(false);
+        when(configuration.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
+        when(configuration.getKeyResolver()).thenReturn(keyResolver);
+        when(configuration.getContent()).thenReturn(keystorePath);
+        when(configuration.getAlias()).thenReturn(KEYSTORE_ALIAS);
+        when(configuration.getStorepass()).thenReturn(KEYSTORE_STOREPASS);
+        when(configuration.getKeypass()).thenReturn(KEYSTORE_KEYPASS);
+
+        KeyStore mismatchedKeyStore = mock(KeyStore.class);
+        when(mismatchedKeyStore.getCertificateChain(KEYSTORE_ALIAS)).thenReturn(mismatchedChain);
+        when(mismatchedKeyStore.getEntry(eq(KEYSTORE_ALIAS), any())).thenReturn(realPrivateKeyEntry);
+
+        try (MockedStatic<KeyStore> keyStoreStatic = mockStatic(KeyStore.class)) {
+            keyStoreStatic.when(() -> KeyStore.getInstance(keyResolver.name())).thenReturn(mismatchedKeyStore);
+
+            GenerateJwtPolicy policy = new GenerateJwtPolicy(configuration);
+
+            policy.onRequest(request, response, executionContext, policyChain);
+
+            verify(policyChain, never()).failWith(any());
+            verify(policyChain).doNext(request, response);
+            ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+            verify(executionContext).setAttribute(eq(GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED), jwtCaptor.capture());
+            Map<String, Object> header = decodeHeader(jwtCaptor.getValue());
+            assertEquals(
+                Set.of("alg", "x5c"),
+                header.keySet(),
+                "the leaf-mismatch header must carry exactly alg and x5c — no x5t/x5t#S256 member may leak in when the thumbprint toggles are off"
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = KeyResolver.class, names = { "JKS", "PKCS12" })
+    void reEmitsCachedX5cOnWarmRequestWithoutReReadingKeystore_whenLeafDoesNotMatchSigningKeyAndThumbprintTogglesDisabled(
+        KeyResolver keyResolver
+    ) throws Exception {
+        String keystoreFile = keyResolver == KeyResolver.JKS ? "/graviteeio.jks" : "/graviteeio.p12";
+        String keystorePath = Path.of(getClass().getResource(keystoreFile).toURI()).toString();
+        KeyStore.PrivateKeyEntry realPrivateKeyEntry = loadRealPrivateKeyEntry(keyResolver, keystorePath);
+        Certificate foreignCertificate = foreignLeafCertificate();
+        Certificate[] mismatchedChain = { foreignCertificate, realPrivateKeyEntry.getCertificate() };
+
+        assertFalse(
+            Arrays.equals(realPrivateKeyEntry.getCertificate().getPublicKey().getEncoded(), foreignCertificate.getPublicKey().getEncoded()),
+            "pre-condition: the keystore chain's leaf certificate must carry a different public key than the resolved signing key"
+        );
+
+        when(configuration.getSignature()).thenReturn(Signature.RSA_RS256);
+        when(configuration.isX509CertSha1Thumbprint()).thenReturn(false);
+        when(configuration.isX509CertSha256Thumbprint()).thenReturn(false);
+        when(configuration.getX509CertificateChain()).thenReturn(X509CertificateChain.X5C);
+        when(configuration.getKeyResolver()).thenReturn(keyResolver);
+        when(configuration.getContent()).thenReturn(keystorePath);
+        when(configuration.getAlias()).thenReturn(KEYSTORE_ALIAS);
+        when(configuration.getStorepass()).thenReturn(KEYSTORE_STOREPASS);
+        when(configuration.getKeypass()).thenReturn(KEYSTORE_KEYPASS);
+
+        KeyStore mismatchedKeyStore = mock(KeyStore.class);
+        when(mismatchedKeyStore.getCertificateChain(KEYSTORE_ALIAS)).thenReturn(mismatchedChain);
+        when(mismatchedKeyStore.getEntry(eq(KEYSTORE_ALIAS), any())).thenReturn(realPrivateKeyEntry);
+
+        try (MockedStatic<KeyStore> keyStoreStatic = mockStatic(KeyStore.class)) {
+            keyStoreStatic.when(() -> KeyStore.getInstance(keyResolver.name())).thenReturn(mismatchedKeyStore);
+
+            GenerateJwtPolicy policy = new GenerateJwtPolicy(configuration);
+
+            policy.onRequest(request, response, executionContext, policyChain);
+            policy.onRequest(request, response, executionContext, policyChain);
+
+            verify(policyChain, never()).failWith(any());
+            verify(policyChain, times(2)).doNext(request, response);
+            verify(mismatchedKeyStore, times(1)).getCertificateChain(KEYSTORE_ALIAS);
+            ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+            verify(executionContext, times(2)).setAttribute(eq(GenerateJwtPolicy.CONTEXT_ATTRIBUTE_JWT_GENERATED), jwtCaptor.capture());
+            for (String jwt : jwtCaptor.getAllValues()) {
+                var x5c = SignedJWT.parse(jwt).getHeader().getX509CertChain();
+                assertNotNull(x5c, "x5c must be re-emitted from the persisted chain cache on both the cold and the warm request");
+                assertEquals(mismatchedChain.length, x5c.size(), "x5c must contain every certificate returned by the keystore chain");
+                for (int i = 0; i < mismatchedChain.length; i++) {
+                    assertArrayEquals(
+                        mismatchedChain[i].getEncoded(),
+                        x5c.get(i).decode(),
+                        "x5c entry " + i + " must be the keystore chain certificate, byte-for-byte, in keystore order"
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Issue

[APIM-14682](https://gravitee.atlassian.net/browse/APIM-14682)

## Purpose

The x5t/x5t#S256 work on this line made the JKS/PKCS12 `x5c` path stricter than `master`: it started verifying the keystore's leaf certificate against the signing key before embedding `x5c`, and started hard-failing the request with HTTP 500 whenever the keystore's certificate chain was null, empty, or unverified. `master` has neither behavior — it embeds whatever `KeyStore.getCertificateChain(alias)` returns, and simply omits `x5c` (without failing the request) when no chain is available. This PR restores that `master` behavior for JKS/PKCS12 while leaving `x5t`/`x5t#S256` fail-fast semantics untouched.

## Summary of changes

- `GenerateJwtPolicy#buildRsaHeader` / `resolveCertChain`: `x5c` is now embedded whenever a non-empty chain is cached, with no leaf-vs-signing-key verification gating it; a missing/empty chain from the keystore no longer rejects the request — `x5c` is simply omitted and signing continues (fail-open, JKS/PKCS12 only).
- `GenerateJwtPolicy#addCertificateChain`: the chain is now cached (and thus eligible for `x5c`) before the leaf-match check runs. The leaf-match check still runs afterward, but now only gates `x5t`/`x5t#S256` (via `logSuppressedThumbprintToggles`, split out of the former combined `logSuppressedChainToggles`) — it no longer clears the cached chain or blocks `x5c`.
- PEM/INLINE resolvers (`addLeafCertificate` / `orderCertificateChain` / `findSigningCertificate`) are untouched by this PR and out of scope here (sibling story APIM-14662). Note `x5c` support for PEM/INLINE doesn't exist on `master` at all — `master`'s `addCertificateChain` call (the only thing that ever populates `x5c`) is wired up for the JKS/PKCS12 branches only; PEM/INLINE never call it, so `x5c` is always absent there regardless of configuration. `x5c` support for PEM/INLINE is new functionality added on `alpha`, and it differs from the JKS/PKCS12 behavior this PR restores in two ways:
  - **Verification**: `addLeafCertificate` only caches a chain for `x5c` when `findSigningCertificate` finds a certificate in the PEM bundle whose public key actually matches the signing key. JKS/PKCS12 performs no such verification for `x5c` as of this PR — it embeds whatever `KeyStore.getCertificateChain(alias)` returns, matching or not.
  - **Fail-open vs. fail-closed**: when PEM/INLINE has no `x5c`-eligible chain cached, `buildRsaHeader` still hard-fails the request with HTTP 500 (`resolveCertChain` → `policyChain.failWith`), because `isKeystoreResolver()` is `false` for PEM/INLINE. JKS/PKCS12 is fail-open in that same situation as of this PR — it omits `x5c` and signs successfully.
- Test coverage in `GenerateJwtPolicyX5tFailFastTest` updated/added: null vs. empty keystore chain now asserts successful signing with no `x5c` header (previously asserted a 500), warm-cache re-emission of the omitted `x5c` on a second request without re-reading the keystore, and new coverage for `x5c` embedding a leaf-mismatched chain byte-for-byte with only `alg`/`x5c` header members present.

### Behaviour changes

- JKS/PKCS12 + `X509CertificateChain.X5C`: a keystore chain whose leaf doesn't match the signing key is now embedded as `x5c` as-is (previously the whole chain was suppressed).
- JKS/PKCS12 + `X509CertificateChain.X5C` with both thumbprint toggles disabled: a null/empty keystore chain no longer fails the request with HTTP 500 — the JWT is signed successfully with `x5c` omitted.
- `x5t`/`x5t#S256` fail-fast behavior (HTTP 500 on missing/mismatched chain when either toggle is enabled) is unchanged.
- PEM/INLINE `x5c` behavior (verification-gated, fail-closed, and non-existent on `master`) is unchanged — see the PEM/INLINE bullet above for how it now differs from JKS/PKCS12.

## Out of scope

- The `storepass`-required check in `getSigner` (JKS/PKCS12) — verified there is no behavioral regression there; not touched.
- PEM/INLINE `x5c` chain construction — covered by the sibling story APIM-14662.

## Related PRs / tickets

- Sibling story: [APIM-14662](https://gravitee.atlassian.net/browse/APIM-14662) (PEM/INLINE `x5c` chain construction, same underlying regression class, out of scope here)


[APIM-14682]: https://gravitee.atlassian.net/browse/APIM-14682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-14662]: https://gravitee.atlassian.net/browse/APIM-14662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.0-cosoriog-APIM-14682-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.9.0-cosoriog-APIM-14682-SNAPSHOT/gravitee-policy-generate-jwt-1.9.0-cosoriog-APIM-14682-SNAPSHOT.zip)
  <!-- Version placeholder end -->
