### PR TITLE
fix: capitalize Key ID in README configuration table

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ When a signed JWT is generated, it is put in the `jwt.generated` attribute of th
 
 .^|kid
 ^.^|-
-|key ID (`kid`) to include in the JWT header
+|Key ID (`kid`) to include in the JWT header
 ^.^|string
 ^.^|-
 


### PR DESCRIPTION
## Summary
- Capitalizes "Key ID" in the README configuration table for consistency with the other rows.
- Also serves as the release-trigger commit that PR #92 was meant to be — that PR merged with a single empty commit, and GitHub's squash/rebase merge produced no diff, so it silently created no commit on `alpha` and no release fired. This PR carries a real one-line change so the merge isn't a no-op.

## Test plan
- N/A (docs-only change)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.0-andres-osorio-alpha-x5c-graceful-degrade-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-generate-jwt/1.9.0-andres-osorio-alpha-x5c-graceful-degrade-fix-SNAPSHOT/gravitee-policy-generate-jwt-1.9.0-andres-osorio-alpha-x5c-graceful-degrade-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
